### PR TITLE
#7 Add default code style configuration

### DIFF
--- a/codestyles/default/css-formatter.properties
+++ b/codestyles/default/css-formatter.properties
@@ -1,0 +1,16 @@
+# CSS Formatter Konfiguration
+# 2 Spaces Einrückung
+indentSize=2
+indentChar=space
+
+# Datei mit neuer Zeile beenden
+endWithNewline=true
+
+# Maximale Anzahl leerer Zeilen
+maxEmptyLines=1
+
+# Selektor auf neue Zeile
+selectorSeparatorNewline=true
+
+# Space vor öffnender Klammer
+rulesetOpeningBraceSpace=true

--- a/codestyles/default/html-formatter.properties
+++ b/codestyles/default/html-formatter.properties
@@ -1,0 +1,16 @@
+# HTML Formatter Konfiguration
+# 2 Spaces Einrückung
+indentAmount=2
+indentChar=space
+
+# Maximale Zeilenlänge
+maxLineLength=120
+
+# Neue Zeilen beibehalten
+preserveNewlines=true
+
+# Whitespace in Text-Knoten beibehalten
+preserveWhitespace=false
+
+# Attribute umbrechen
+wrapAttributes=auto

--- a/codestyles/default/java-formatter.xml
+++ b/codestyles/default/java-formatter.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="21">
+    <profile kind="CodeFormatterProfile" name="DemoJavaStyle" version="21">
+        <!-- SPACES ONLY - 4 Spaces für Java -->
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        
+        <!-- Zeilen-Länge -->
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+        
+        <!-- Klammern am Zeilenende (K&R Style) -->
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        
+        <!-- Leerzeilen -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        
+        <!-- Continuation Indentation -->
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        
+        <!-- Wrapping -->
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        
+        <!-- Spaces -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        
+        <!-- New Line -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        
+        <!-- Java 8+ Features -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        
+        <!-- Comments -->
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+    </profile>
+</profiles>

--- a/codestyles/default/javascript-formatter.xml
+++ b/codestyles/default/javascript-formatter.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="2">
+    <profile kind="JavaScriptFormatterProfile" name="DemoJSStyle" version="2">
+        <!-- 2 Spaces für JavaScript -->
+        <setting id="org.eclipse.wst.jsdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.tabulation.size" value="2"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.indentation.size" value="2"/>
+        
+        <!-- Zeilen-Länge -->
+        <setting id="org.eclipse.wst.jsdt.core.formatter.lineSplit" value="100"/>
+        
+        <!-- Klammern -->
+        <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_function_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        
+        <!-- Semicolons -->
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_semicolon" value="true"/>
+        
+        <!-- Spaces -->
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_function_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_opening_paren_in_function_declaration" value="do not insert"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_opening_paren_in_function_declaration" value="do not insert"/>
+        <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_function_declaration" value="do not insert"/>
+    </profile>
+</profiles>

--- a/codestyles/default/json-formatter.properties
+++ b/codestyles/default/json-formatter.properties
@@ -1,0 +1,12 @@
+# JSON Formatter Konfiguration
+# 2 Spaces Einrückung
+indent=2
+
+# Line Ending (LF für Unix/Linux/Mac)
+lineending=\n
+
+# Kein Space vor dem Doppelpunkt
+spaceBeforeSeparator=false
+
+# Alphabetische Sortierung der Keys (optional)
+alphabeticalOrder=false

--- a/codestyles/default/xml-formatter.properties
+++ b/codestyles/default/xml-formatter.properties
@@ -1,0 +1,15 @@
+# XML Formatter Konfiguration
+# 2 Spaces Einrückung
+indentSize=2
+
+# Maximale Zeilenlänge
+lineWidth=120
+
+# Whitespace nicht erhalten
+preserveSpace=false
+
+# Mehrere Attribute auf separate Zeilen
+splitMultiAttributes=false
+
+# Attribute nicht vertikal ausrichten
+alignAttributesVertically=false


### PR DESCRIPTION
Added modern default code style formatter configurations for multiple languages:
- Java (4 spaces, K&R style)
- JavaScript (2 spaces)
- CSS (2 spaces)
- HTML (2 spaces)
- JSON (2 spaces)
- XML (2 spaces)

Closes #7